### PR TITLE
[TC-176] Update Gemspec info

### DIFF
--- a/event-sourcing.gemspec
+++ b/event-sourcing.gemspec
@@ -8,20 +8,17 @@ Gem::Specification.new do |spec|
   spec.version = EventSourcing::VERSION
   spec.authors = ["The Conversation Dev Team"]
 
-  spec.summary = "TC Event sourcing library"
-  spec.description = "Event sourcing implementation for TC projects"
-  spec.homepage = "https://github.com/conversation/tc-event-sourcing"
+  spec.summary = "The Conversation Event sourcing library"
+  spec.description = "Simple Ruby Event Sourcing framework, with Rails support"
+  spec.homepage = "https://github.com/conversation/event-sourcing"
   spec.license = "MIT"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|examples)/}) }
-  end
+  spec.files = `git ls-files -- lib/*`.split("\n")
+  spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "pg", "~> 1.0"
+  spec.add_development_dependency "rails", "~> 5.0", "< 6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rails", ">= 5"
-  spec.add_development_dependency "pg", ">= 1"
 end

--- a/event-sourcing.gemspec
+++ b/event-sourcing.gemspec
@@ -2,7 +2,6 @@ lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require "event_sourcing/version"
-require "event_sourcing"
 
 Gem::Specification.new do |spec|
   spec.name = "event-sourcing"

--- a/lib/event_sourcing/rails.rb
+++ b/lib/event_sourcing/rails.rb
@@ -1,2 +1,3 @@
+require "event_sourcing"
 require "event_sourcing/rails/command_record"
 require "event_sourcing/rails/event_record"

--- a/lib/event_sourcing/version.rb
+++ b/lib/event_sourcing/version.rb
@@ -1,3 +1,3 @@
 module EventSourcing
-  VERSION = "0.2.0.pre"
+  VERSION = "0.2.1.pre"
 end


### PR DESCRIPTION
This PR updates `event-sourcing` gemspec information to fix the following issues:

- Do not require the library at the gemspec
- Expand the TC acronym to "The Conversation"
- Update the gem description to match GitHub's repository description
- Point to the correct GitHub repository URL as a homepage URL
- Simplify the gemspec file reference
- Add an explicit require path
- Do not use open ended version locks for development dependencies

This PR also allows the `event_sourcing/rails` file to require the base library file (`require "event_sourcing"`), since all Rails sub-modules require it.