### PR TITLE
Rename AR command and event classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # EventSourcing
 
-Simple Ruby Event Sourcing framework, with Rails support. Inspired by [Kickstarter](https://www.kickstarter.com/)'s 
+Simple Ruby Event Sourcing framework, with Rails support. Inspired by [Kickstarter](https://www.kickstarter.com/)'s
 ["Event Sourcing made Simple"](https://kickstarter.engineering/event-sourcing-made-simple-4a2625113224) blog post.
 
-`EventSourcing` gives you a toolset to configure and store sequences of events on any Ruby application, making it 
+`EventSourcing` gives you a toolset to configure and store sequences of events on any Ruby application, making it
 possible to query an object state at any given point of time.
 
-As Martin Fowler describes the Event Sourcing concept:  
+As Martin Fowler describes the Event Sourcing concept:
 
-> Event Sourcing ensures that all changes to application state are stored as a sequence of events. Not just can we query 
-these events, we can also use the event log to reconstruct past states, and as a foundation to automatically adjust the 
+> Event Sourcing ensures that all changes to application state are stored as a sequence of events. Not just can we query
+these events, we can also use the event log to reconstruct past states, and as a foundation to automatically adjust the
 state to cope with retroactive changes.
 > - Source: https://martinfowler.com/eaaDev/EventSourcing.html
 
@@ -28,7 +28,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install event-sourcing
-    
+
 ## Concepts
 
 This frameworks introduces artifacts and rules to keep track of object state changes.
@@ -54,11 +54,11 @@ While state changing actions obey the rationale:
 This framework can be used on any Ruby project, as it allows you to customize how you can handle Event persistence and
 event dispatching control flow.
 
-You can find an implementation sample at the [PORO app's README file](examples/poro_app/README.md).  
+You can find an implementation sample at the [PORO app's README file](examples/poro_app/README.md).
 
 ## Usage with Rails
 
-You can also use this framework with Rails, as it includes an `event_sourcing/rails` module to ease up configuration.
+You can also use this framework with Rails, as it includes an `event_sourcing/active_record` module to ease up configuration.
 
 **Note:** this Rails implementation requires a database that implements serializable attributes by default,
 such as PostgreSQL JSON/Binary JSON columns.
@@ -66,7 +66,7 @@ such as PostgreSQL JSON/Binary JSON columns.
 To include the Rails module, add this line to your application's Gemfile:
 
 ```ruby
-gem "event-sourcing", require: "event_sourcing/rails"
+gem "event-sourcing", require: "event_sourcing/active_record"
 ```
 
 Further installation steps and a sample implementation can be found at the [Rails' README file](examples/rails_app/README.md).
@@ -77,7 +77,7 @@ Further installation steps and a sample implementation can be found at the [Rail
     - Postgres 8.4+
     - Ruby 2.3+
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. 
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests.
 
 You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
@@ -99,4 +99,4 @@ expected to follow the [code of conduct](https://github.com/conversation/event-s
 ## Related Projects
 
 Thank you very much [Kickstarter](https://www.kickstarter.com/) for making the ["Event Sourcing made Simple"](https://kickstarter.engineering/event-sourcing-made-simple-4a2625113224)
-blog post. This project is heavily inspired on concepts described on it and its [Rails demo app](https://github.com/pcreux/event-sourcing-rails-todo-app-demo). 
+blog post. This project is heavily inspired on concepts described on it and its [Rails demo app](https://github.com/pcreux/event-sourcing-rails-todo-app-demo).

--- a/examples/rails_app/Gemfile
+++ b/examples/rails_app/Gemfile
@@ -40,4 +40,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "event-sourcing", path: "../../../event-sourcing", require: "event_sourcing/rails"
+gem "event-sourcing", path: "../../../event-sourcing", require: "event_sourcing/active_record"

--- a/examples/rails_app/README.md
+++ b/examples/rails_app/README.md
@@ -15,7 +15,7 @@ Rails is a strong opinionated framework, so there are a couple of points to keep
 ```ruby
 class BaseEvent < ApplicationRecord
   include EventSourcing::Event
-  include EventSourcing::Rails::EventRecord
+  include EventSourcing::ActiveRecord::Event
 
   self.abstract_class = true
 end
@@ -34,7 +34,7 @@ class MyEvent < BaseEvent
     aggregate.name = name
     aggregate
   end
-  
+
   def build_aggregate
     @aggregate ||= MyModel.find(record_id)
   end
@@ -45,11 +45,11 @@ end
 - Events must have a `belongs_to` relationship
     - Motive: this one-to-many association represents the events-aggregator relationship
     - Example:
-    
+
 ```ruby
 class BaseEvent < ApplicationRecord
   include EventSourcing::Event
-  include EventSourcing::Rails::EventRecord
+  include EventSourcing::ActiveRecord::Event
 
   belongs_to :user
 end
@@ -95,7 +95,7 @@ end
 
 ## Reactors
 
-Reactors are 
+Reactors are
 
 - [Log User Change Reactor](app/models/users/reactors/log_user_change.rb)
 - [Send Getting Started Email Reactor](app/models/users/reactors/send_getting_started_email.rb)

--- a/examples/rails_app/app/models/users/commands/create.rb
+++ b/examples/rails_app/app/models/users/commands/create.rb
@@ -2,7 +2,7 @@ module Users
   module Commands
     class Create
       include EventSourcing::Command
-      include EventSourcing::Rails::CommandRecord
+      include EventSourcing::ActiveRecord::Command
 
       attributes :description, :name
 

--- a/examples/rails_app/app/models/users/commands/destroy.rb
+++ b/examples/rails_app/app/models/users/commands/destroy.rb
@@ -2,7 +2,7 @@ module Users
   module Commands
     class Destroy
       include EventSourcing::Command
-      include EventSourcing::Rails::CommandRecord
+      include EventSourcing::ActiveRecord::Command
 
       attributes :record_id
 

--- a/examples/rails_app/app/models/users/commands/update.rb
+++ b/examples/rails_app/app/models/users/commands/update.rb
@@ -2,7 +2,7 @@ module Users
   module Commands
     class Update
       include EventSourcing::Command
-      include EventSourcing::Rails::CommandRecord
+      include EventSourcing::ActiveRecord::Command
 
       attributes :active, :description, :record_id, :name
 

--- a/examples/rails_app/app/models/users/events/base.rb
+++ b/examples/rails_app/app/models/users/events/base.rb
@@ -2,7 +2,7 @@ module Users
   module Events
     class Base < ApplicationRecord
       include EventSourcing::Event
-      include EventSourcing::Rails::EventRecord
+      include EventSourcing::ActiveRecord::Event
 
       self.table_name = :user_events
       self.abstract_class = true

--- a/lib/event_sourcing/active_record.rb
+++ b/lib/event_sourcing/active_record.rb
@@ -1,0 +1,3 @@
+require "event_sourcing"
+require "event_sourcing/active_record/command"
+require "event_sourcing/active_record/event"

--- a/lib/event_sourcing/active_record/command.rb
+++ b/lib/event_sourcing/active_record/command.rb
@@ -1,6 +1,6 @@
 module EventSourcing
-  module Rails
-    module CommandRecord
+  module ActiveRecord
+    module Command
       extend ActiveSupport::Concern
 
       included do

--- a/lib/event_sourcing/active_record/event.rb
+++ b/lib/event_sourcing/active_record/event.rb
@@ -1,6 +1,6 @@
 module EventSourcing
-  module Rails
-    module EventRecord
+  module ActiveRecord
+    module Event
       extend ActiveSupport::Concern
 
       class_methods do

--- a/lib/event_sourcing/rails.rb
+++ b/lib/event_sourcing/rails.rb
@@ -1,3 +1,0 @@
-require "event_sourcing"
-require "event_sourcing/rails/command_record"
-require "event_sourcing/rails/event_record"

--- a/lib/event_sourcing/version.rb
+++ b/lib/event_sourcing/version.rb
@@ -1,3 +1,3 @@
 module EventSourcing
-  VERSION = "0.2.1.pre"
+  VERSION = "0.3.1.pre"
 end

--- a/spec/lib/event_sourcing/active_record/command_spec.rb
+++ b/spec/lib/event_sourcing/active_record/command_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe EventSourcing::Rails::CommandRecord do
+RSpec.describe EventSourcing::ActiveRecord::Command do
   subject(:command) { RailsUserCreateCommand.new(name: given_name) }
 
   let(:given_name) { "Not long enough" }

--- a/spec/lib/event_sourcing/active_record/event_spec.rb
+++ b/spec/lib/event_sourcing/active_record/event_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe EventSourcing::Rails::EventRecord do
+RSpec.describe EventSourcing::ActiveRecord::Event do
   let(:event) { RailsUserCreated.assign(name: "John Doe") }
   let(:event_class) { RailsUserCreated }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 require "active_support"
 require "active_model"
 require "active_record"
-require "event_sourcing/rails"
+require "event_sourcing/active_record"
 
 require "support/migration"
 require "support/rails/test_models"

--- a/spec/support/rails/test_models.rb
+++ b/spec/support/rails/test_models.rb
@@ -6,7 +6,7 @@ end
 
 class RailsUserEvent < ActiveRecord::Base
   include EventSourcing::Event
-  include EventSourcing::Rails::EventRecord
+  include EventSourcing::ActiveRecord::Event
 
   self.table_name = :user_events
   self.abstract_class = true
@@ -54,7 +54,7 @@ end
 
 class RailsUserCreateCommand
   include EventSourcing::Command
-  include EventSourcing::Rails::CommandRecord
+  include EventSourcing::ActiveRecord::Command
 
   attributes :name
 
@@ -69,7 +69,7 @@ end
 
 class RailsUserUpdateCommand
   include EventSourcing::Command
-  include EventSourcing::Rails::CommandRecord
+  include EventSourcing::ActiveRecord::Command
 
   attributes :name, :record_id
 


### PR DESCRIPTION
This PR makes some changes to the ActiveRecord command and event mixin classes. I think putting them in the `Rails` namespace was misleading, because it is possible to run Rails with another persistence layer (e.g. Sequel).

I have instead moved them into the `ActiveRecord` namespace. I also dropped the `Record` suffix for those class names, as I don't think it adds anything useful. The mixins are now called `EventSourcing::ActiveRecord::Command` and `EventSourcing::ActiveRecord::Event`.