### PR TITLE
[RFC] Create ActiveRecord::Event#reify method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 0.4.1.pre
+
+- Added the `EventSourcing::ActiveRecord::Event#reify` method
+
+# 0.3.1.pre
+
+- Renamed the `EventSourcing::Rails` module to `EventSourcing::ActiveRecord` (@nullobject)
+    - Renamed the `EventSourcing::Rails::CommandRecord` to `EventSourcing::ActiveRecord::Command`
+    - Renamed the `EventSourcing::Rails::EventRecord` to `EventSourcing::ActiveRecord::Event`

--- a/lib/event_sourcing/active_record/event.rb
+++ b/lib/event_sourcing/active_record/event.rb
@@ -87,6 +87,13 @@ module EventSourcing
         ::ActiveRecord::Base.transaction(requires_new: true) do
           yield
         end
+
+      # @return [Class] Given class from metadata[:klass]
+      # Materializes the event class from the database
+      def reify
+        event_class = Object.const_get(metadata[:klass])
+        event_class.find(self[:id])
+      end
       end
     end
   end

--- a/lib/event_sourcing/version.rb
+++ b/lib/event_sourcing/version.rb
@@ -1,3 +1,3 @@
 module EventSourcing
-  VERSION = "0.3.1.pre"
+  VERSION = "0.4.1.pre"
 end

--- a/spec/lib/event_sourcing/active_record/event_spec.rb
+++ b/spec/lib/event_sourcing/active_record/event_spec.rb
@@ -144,5 +144,23 @@ RSpec.describe EventSourcing::ActiveRecord::Event do
         end
       end
     end
+
+    describe "#reify" do
+      let(:user) { RailsUser.create(name: "John Doe") }
+
+      before do
+        RailsUserUpdateCommand.call(record_id: user.id, name: "My Super Foo Bar Name")
+      end
+
+      it "materializes the aggregate event record from its serialized form" do
+        event = user.events.last.reify
+
+        expect(event).to be_an_instance_of(RailsUserUpdated)
+        expect(event).to have_attributes(
+          data: { name: "My Super Foo Bar Name", record_id: user.id },
+          metadata: { klass: "RailsUserUpdated" }
+        )
+      end
+    end
   end
 end

--- a/spec/lib/event_sourcing/event_spec.rb
+++ b/spec/lib/event_sourcing/event_spec.rb
@@ -7,7 +7,6 @@ end
 
 class CreatedEvent
   include EventSourcing::Event
-
 end
 
 class UpdatedEvent


### PR DESCRIPTION
This PR creates the `ActiveRecord::Event#reify` method (thank you @RohanM for the idea! 👏).

This method materializes a serialized event from the database without having to rely on `ActiveRecord`'s STI mechanisms.

With this method, you can easily restore the original . Example:

```ruby
# Given a `User` model with many events inherited from the `Events::User::Base` class

event = user.events.first # => #<Events::User::Base >
event.reify # => #<Events::User::Updated id: 14 ... >
```

