### PR TITLE
Wraps event persistence and dispatch into a ActiveRecord transaction

### DIFF
--- a/lib/event_sourcing/active_record/event.rb
+++ b/lib/event_sourcing/active_record/event.rb
@@ -80,6 +80,14 @@ module EventSourcing
 
         save!
       end
+
+      # Creates a "nested transaction", forcing a SAVEPOINT in case the event persistence is
+      # called inside an `ActiveRecord#transaction` block
+      def persistence_wrapper
+        ::ActiveRecord::Base.transaction(requires_new: true) do
+          yield
+        end
+      end
     end
   end
 end

--- a/lib/event_sourcing/event.rb
+++ b/lib/event_sourcing/event.rb
@@ -105,16 +105,24 @@ module EventSourcing
     end
 
     def persist_and_dispatch
-      self.aggregate = build_aggregate
+      persistence_wrapper do
+        self.aggregate = build_aggregate
 
-      # Apply
-      self.aggregate = apply(aggregate)
+        # Apply
+        self.aggregate = apply(aggregate)
 
-      # Persist aggregate
-      persist_aggregate
-      persist_event
+        # Persist aggregate
+        persist_aggregate
+        persist_event
 
-      dispatch
+        dispatch
+      end
+    end
+
+    # Customizable persistence wrapper for the event persistence and dispatch method
+    # Allows to wrap aggregate and event persistence into a transaction
+    def persistence_wrapper
+      yield
     end
 
     private

--- a/spec/lib/event_sourcing/event_spec.rb
+++ b/spec/lib/event_sourcing/event_spec.rb
@@ -101,4 +101,15 @@ RSpec.describe EventSourcing::Event do
       expect(event).to have_received(:dispatch)
     end
   end
+
+  describe "#persistence_wrapper" do
+    let(:event) { UpdatedEvent.assign(name: "Aunt May") }
+    let(:wrapped_double) { double("Wrapped Double", called: true) }
+
+    it "yields the given block" do
+      event.persistence_wrapper { wrapped_double.called }
+
+      expect(wrapped_double).to have_received(:called)
+    end
+  end
 end

--- a/spec/support/rails/test_models.rb
+++ b/spec/support/rails/test_models.rb
@@ -1,7 +1,7 @@
 class RailsUser < ActiveRecord::Base
   self.table_name = :users
 
-  has_many :events, class_name: "RailsUserEvent"
+  has_many :events, class_name: "RailsUserEvent", foreign_key: "user_id"
 end
 
 class RailsUserEvent < ActiveRecord::Base


### PR DESCRIPTION
This PRs implements @nullobject's suggestion of wrapping event persistence into a transaction. Here's the original quote:

> it is possible to get the database into an inconsistent state because the aggregate and the event aren't persisted in the same database transaction - @nullobject

I'm marking this PR as blocked until https://github.com/conversation/event-sourcing/pull/9 is reviewed and this repository has a CHANGELOG.