### PR TITLE
Fix indentation/method finish/scope on ActiveRecord::Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 0.4.2.pre
+
+- Fixed `EventSourcing::ActiveRecord::Event#reify` method declaration (@tiagoamaro)
+
 # 0.4.1.pre
 
-- Added the `EventSourcing::ActiveRecord::Event#reify` method
+- Added the `EventSourcing::ActiveRecord::Event#reify` method (@RohanM)
 
 # 0.3.1.pre
 

--- a/lib/event_sourcing/active_record/event.rb
+++ b/lib/event_sourcing/active_record/event.rb
@@ -87,13 +87,13 @@ module EventSourcing
         ::ActiveRecord::Base.transaction(requires_new: true) do
           yield
         end
+      end
 
       # @return [Class] Given class from metadata[:klass]
       # Materializes the event class from the database
       def reify
         event_class = Object.const_get(metadata[:klass])
         event_class.find(self[:id])
-      end
       end
     end
   end

--- a/lib/event_sourcing/version.rb
+++ b/lib/event_sourcing/version.rb
@@ -1,3 +1,3 @@
 module EventSourcing
-  VERSION = "0.4.1.pre"
+  VERSION = "0.4.2.pre"
 end


### PR DESCRIPTION
ActiveRecord::Event#reify declaration lived inside ActiveRecord::Event#persistence_wrapper